### PR TITLE
to allow this plugin to be installed at *wp-content/plugins* instead of the default *vendor* folder when used with composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "ssovit/acf-sliders",
     "description": "ACF Slider addon for Advanced Custom Fields",
     "license": "GPL-2.0+",
+    "type": "wordpress-plugin",
     "authors": [{
         "name": "Sovit Tamrakar",
         "email": "sovit.tamrakar@gmail.com",


### PR DESCRIPTION
"to allow this plugin to be installed at *wp-content/plugins* instead of the default *vendor* folder when used with composer/installers"

PS: Read more at: https://github.com/composer/installers, search for "wordpress".